### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mmarting/unwaf
 
-go 1.22.5
+go 1.23
 
 require (
 	github.com/fatih/color v1.17.0


### PR DESCRIPTION
When trying to download the tool, this message appears go install github.com/mmarting/unwaf@latest
Please modify the third line of the go.mod file from 1.22.5 to 1.23