### PR TITLE
feat: add enumeration with custom IP list

### DIFF
--- a/display.go
+++ b/display.go
@@ -36,6 +36,7 @@ Usage:
   --scan-neighbors    Scan /24 neighbors of confirmed bypass IPs (optional)
   --json              Output results as JSON
   -l, --list          File containing domains to check, one per line
+  -I, --ip-list       File containing custom IPs to check, one per line
   -o, --output        Write results to file
   --version           Print version and exit
   -h, --help          Display help information
@@ -68,6 +69,9 @@ Examples:
   9. Scan /24 neighbors of bypass IPs:
      unwaf -d example.com --scan-neighbors
 
+  10. Use a custom IP list for checking:
+      unwaf -d example.com -I ips.txt
+
 Discovery methods:
   [FREE]    SPF records (ip4/ip6 mechanisms)
   [FREE]    MX records (mail server IPs)
@@ -79,6 +83,7 @@ Discovery methods:
   [FREE]    RapidDNS subdomain enumeration
   [FREE]    HackerTarget host search
   [FREE]    Wayback Machine archived URLs
+  [FREE]    Custom IP list (manually provided)
   [API free] Shodan host search (free API key, by SSL cert/hostname/favicon)
   [API free] SecurityTrails DNS history (free tier, 50 req/month)
   [API paid] ViewDNS IP history

--- a/main.go
+++ b/main.go
@@ -51,6 +51,8 @@ func main() {
 	flag.StringVar(listFile, "l", "", "File containing domains (shorthand)")
 	outputFile := flag.String("output", "", "Write results to file")
 	flag.StringVar(outputFile, "o", "", "Write results to file (shorthand)")
+	ipListFile := flag.String("ip-list", "", "File containing custom IPs to check, one per line")
+	flag.StringVar(ipListFile, "I", "", "File containing custom IPs (shorthand)")
 
 	flag.Parse()
 
@@ -119,6 +121,28 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Collect custom IPs
+	var customIPs []string
+	if *ipListFile != "" {
+		f, err := os.Open(*ipListFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error opening IP list file: %v\n", err)
+			os.Exit(1)
+		}
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			// Basic IP validation
+			if ip := net.ParseIP(line); ip != nil {
+				customIPs = append(customIPs, line)
+			}
+		}
+		f.Close()
+	}
+
 	portTimeout := timeout / 5
 	if portTimeout < 2*time.Second {
 		portTimeout = 2 * time.Second
@@ -134,6 +158,7 @@ func main() {
 		jsonMode:      *jsonOutput,
 		outputFile:    *outputFile,
 		portTimeout:   portTimeout,
+		customIPs:     customIPs,
 	}
 
 	if *jsonOutput && len(domains) > 1 {
@@ -187,6 +212,7 @@ type processOptions struct {
 	jsonMode      bool
 	outputFile    string
 	portTimeout   time.Duration
+	customIPs     []string
 }
 
 type discoveryStep struct {
@@ -328,6 +354,11 @@ func processDomain(ctx context.Context, domain string, opts *processOptions) *JS
 		}
 		allIPs = append(allIPs, ips...)
 		jsonOut.Sources[source] = len(ips)
+	}
+
+	// Add custom IPs first if provided
+	if len(opts.customIPs) > 0 {
+		addIPs("Custom IP List", opts.customIPs)
 	}
 
 	// Build dynamic discovery steps


### PR DESCRIPTION
### Feature: Custom IP List Enumeration

This pull request introduces support for enumerating targets using a user-provided list of IP addresses.

### What’s Added

* New CLI flag:

  * `--ip-list`
  * `-I` (shorthand)
* Allows users to provide a file containing custom IP addresses (one per line)
* Enables more flexible and targeted enumeration workflows

### Usage Example

```bash
unwaf -I ips.txt
```

###  Details

* The tool reads IPs from the specified file
* Each IP is processed as part of the enumeration pipeline
* Useful for scenarios where domains are not available or IP-based targeting is required

### Why This Matters

* Expands tool capability beyond domain-based enumeration
* Supports advanced use cases like infrastructure testing and recon on known IP ranges